### PR TITLE
S3o set cookies after authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ ft-s3o-go
 
 [![CircleCI](https://circleci.com/gh/Financial-Times/ft-s3o-go.svg?style=svg)](https://circleci.com/gh/Financial-Times/ft-s3o-go)
 
-Go middleware for FT s3o staff single signon
+Go middleware to handle authenticating with [S3O](http://s3o.ft.com/docs)
 
-THIS IS NOT PRODUCTION READY YET.  DO NOT DEPEND ON THIS FOR ANY KIND OF SECURITY.
+* If the user is not authenticated, the library redirects to S3O for authentication. 
+* `username` and `token` cookies will be stored after a successful auth. 
 
-For documentation, click this link:-
-
+For documentation, click this link:
 [![GoDoc](https://godoc.org/github.com/Financial-Times/ft-s3o-go/s3o?status.svg)](https://godoc.org/github.com/Financial-Times/ft-s3o-go/s3o)

--- a/s3o/s3o.go
+++ b/s3o/s3o.go
@@ -123,7 +123,7 @@ func Handler(next http.Handler) http.Handler {
 		} else {
 			// send the user to s3o to authenticate
 			proto := "http"
-			if r.Header.Get("X-Fordwarded-Proto") == "https" {
+			if r.Header.Get("X-Forwarded-Proto") == "https" || r.Header.Get(":scheme") == "https" {
 				proto = "https"
 			}
 			query := ""

--- a/s3o/s3o.go
+++ b/s3o/s3o.go
@@ -123,7 +123,7 @@ func Handler(next http.Handler) http.Handler {
 		} else {
 			// send the user to s3o to authenticate
 			proto := "http"
-			if r.TLS != nil {
+			if r.Header.Get("X-Fordwarded-Proto") == "https" {
 				proto = "https"
 			}
 			query := ""


### PR DESCRIPTION
When auth successful, write username and token cookies; check if cookies are set instead of asking for authentication each time.